### PR TITLE
Add dedicated class for controller (fix route caching)

### DIFF
--- a/src/GraphQLPlaygroundController.php
+++ b/src/GraphQLPlaygroundController.php
@@ -2,12 +2,11 @@
 
 namespace MLL\GraphQLPlayground;
 
-use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 
 class GraphQLPlaygroundController extends Controller
 {
-    public function get(Request $request)
+    public function get()
     {
         return view('graphql-playground::index');
     }

--- a/src/GraphQLPlaygroundController.php
+++ b/src/GraphQLPlaygroundController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MLL\GraphQLPlayground;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class GraphQLPlaygroundController extends Controller
+{
+    public function get(Request $request)
+    {
+        return view('graphql-playground::index');
+    }
+}

--- a/src/GraphQLPlaygroundServiceProvider.php
+++ b/src/GraphQLPlaygroundServiceProvider.php
@@ -33,7 +33,9 @@ class GraphQLPlaygroundServiceProvider extends ServiceProvider
         \Route::get(
             config('graphql-playground.route'),
             GraphQLPlaygroundController::class . '@get'
-        )->middleware(config('graphql-playground.middleware', ''));
+        )->middleware(
+            config('graphql-playground.middleware')
+        );
     }
 
     /**

--- a/src/GraphQLPlaygroundServiceProvider.php
+++ b/src/GraphQLPlaygroundServiceProvider.php
@@ -30,13 +30,10 @@ class GraphQLPlaygroundServiceProvider extends ServiceProvider
             return;
         }
 
-        \Route::get(config('graphql-playground.route'), [
-            'middleware' => config('graphql-playground.middleware', ''),
-            'as' => 'graphql-playgroundcontroller',
-            'uses' => function () {
-                return view('graphql-playground::index');
-            },
-        ]);
+        \Route::get(
+            config('graphql-playground.route'),
+            GraphQLPlaygroundController::class . '@get'
+        )->middleware(config('graphql-playground.middleware', ''));
     }
 
     /**


### PR DESCRIPTION
Without this PR this package adds a route with an anonymous controller function. This is incompatible with native Laravel route caching, causing the following exception:

```bash
$ php artisan route:cache
Route cache cleared!

   LogicException  : Unable to prepare route [graphql-playground] for serialization. Uses Closure.

  at /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Route.php:880
    876|      */
    877|     public function prepareForSerialization()
    878|     {
    879|         if ($this->action['uses'] instanceof Closure) {
  > 880|             throw new LogicException("Unable to prepare route [{$this->uri}] for serialization. Uses Closure.");
    881|         }
    882| 
    883|         $this->compileRoute();
    884| 

  Exception trace:

  1   Illuminate\Routing\Route::prepareForSerialization()
      /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Console/RouteCacheCommand.php:62

  2   Illuminate\Foundation\Console\RouteCacheCommand::handle()
      /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:29

  Please use the argument -v to see more details.
```

With this PR route caching is possible again by introducing a controller class for the playground.

It would be nice to have this merged. Please let me know if you require any changes to this PR or have strong opinions against it. Thanks!