### PR TITLE
Use Facade instead of Alias

### DIFF
--- a/src/GraphQLPlaygroundServiceProvider.php
+++ b/src/GraphQLPlaygroundServiceProvider.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace MLL\GraphQLPlayground;
 
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
 
 class GraphQLPlaygroundServiceProvider extends ServiceProvider
 {

--- a/src/GraphQLPlaygroundServiceProvider.php
+++ b/src/GraphQLPlaygroundServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MLL\GraphQLPlayground;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class GraphQLPlaygroundServiceProvider extends ServiceProvider
 {
@@ -32,10 +33,10 @@ class GraphQLPlaygroundServiceProvider extends ServiceProvider
             return;
         }
 
-        \Route::group(
+        Route::group(
             config('graphql-playground.route'),
             function (): void {
-                \Route::get(
+                Route::get(
                     config('graphql-playground.route_name', 'graphql-playground'),
                     GraphQLPlaygroundController::class.'@get'
                 )->name('graphql-playground');


### PR DESCRIPTION
With this change dependent projects do not have to register the "Route" Facade alias in `config/app.php`.