### PR TITLE
Fix vendor:publish tag graphql-playground-view in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $app->configure('graphql-playground');
 
 To customize the Playground even further, publish the view:
 
-    php artisan vendor:publish --tag=graphql-playground-views
+    php artisan vendor:publish --tag=graphql-playground-view
 
 You can use that for all kinds of customization.
 


### PR DESCRIPTION
Tag is registered as "graphql-playground-view" (singular, not plural)