### PR TITLE
Update CSRF header documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ GraphQLPlayground.init(document.getElementById('root'), {
   subscriptionEndpoint: "{{ config('graphql-playground.subscriptionEndpoint') }}",
 + settings: {
 +   'request.credentials': 'same-origin',
-+ },
-+ headers: {
-+   'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
++   'request.globalHeaders': {
++     'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
++   }
 + }
 })
 ```


### PR DESCRIPTION
Since these docs were last updated, GraphQLPlayground [added a `request.globalHeaders` setting](https://github.com/graphql/graphql-playground/pull/992) which is now the correct way to set the CSRF token when required. This PR updates the docs to reflect the new correct configuration.